### PR TITLE
Fix specs status filter

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -160,8 +160,10 @@ let appSpec = {
 				return root;
 			}
 
+			// Get children from the filtered-out specs
 			let children = this.specs.flatMap(spec => spec.children);
 			if (!children.length) {
+				// On app launch, fallback to the children of all known specs
 				children = root.children;
 			}
 

--- a/src/app.js
+++ b/src/app.js
@@ -160,7 +160,12 @@ let appSpec = {
 				return root;
 			}
 
-			let children = this.computedFilter ? root.children.filter(child => child.matchesFilter(this.computedFilter)) : root.children;
+			let children = this.specs.flatMap(spec => spec.children);
+			if (!children.length) {
+				children = root.children;
+			}
+
+			children = this.computedFilter ? children.filter(child => child.matchesFilter(this.computedFilter)) : children;
 			children = this.groupBy.length ? groupFeatures(children, this.groupBy) : children;
 
 			return new FeatureProxy(this.root, children);


### PR DESCRIPTION
Show results based on filtered specs, not all of them.

Now, we work with children of all known specs, regardless of the filter value, since we set it only once (on the app launch): https://github.com/browserscore/app/blob/e8e00acba2c36c869abe086e703bf3713371734f/src/app.js#L3
https://github.com/browserscore/app/blob/e8e00acba2c36c869abe086e703bf3713371734f/src/app.js#L17
https://github.com/browserscore/app/blob/e8e00acba2c36c869abe086e703bf3713371734f/src/app.js#L163

With the change, we use the children of filtered-out specs only (by referring to the computed `this.specs` property):

https://github.com/browserscore/app/blob/e8e00acba2c36c869abe086e703bf3713371734f/src/app.js#L99

On the app launch, we work with the children of all the known specs as before.